### PR TITLE
Add schema creation step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ RUN pip install psycopg2 sentry redis
 EXPOSE 9000
 ADD sentry.conf.py /sentry.conf.py
 
+RUN /usr/local/bin/sentry --config=/sentry.conf.py upgrade
+
 ENTRYPOINT ["/usr/local/bin/sentry", "--config=/sentry.conf.py"]
 CMD ["start"]


### PR DESCRIPTION
According to (http://sentry.readthedocs.org/en/latest/quickstart/) the
initial schema for sentry needs to be created using the upgrade command.
